### PR TITLE
fix: blog-agent.ipynb 가 열리지 않는 이슈

### DIFF
--- a/blog-agent.ipynb
+++ b/blog-agent.ipynb
@@ -171,6 +171,7 @@
     "\n",
     "# 모델 설정 위젯 표시\n",
     "setup_model_configs()"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
- github PR과정에서 174 line에서 ']'이 삭제되어 발생